### PR TITLE
Purge shortest paths list on new path distance

### DIFF
--- a/algorithms/shortest_path.py
+++ b/algorithms/shortest_path.py
@@ -59,6 +59,7 @@ def single_source_shortest_paths_dijkstra(graph: Graph, source: int, cutoff=None
             elif u not in visited or vu_distance < visited[u]:  # shorter path found
                 visited[u] = vu_distance
                 heappush(heap, (vu_distance, v, u))
+                paths[u] = []
                 _update_paths(paths, u, v)
                 predecessors[u] = [v]
 


### PR DESCRIPTION
The list of shortest paths to a node was not emptied when a new shortest distance was found.